### PR TITLE
fix: make DataDog API key optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ USAGE:
 
 ENVIRONMENT VARIABLE
 
-  DATADOG_APK_KEY (required) - DataDog APK Key
+  DATADOG_API_KEY - DataDog API Key. If DATADOG_API_KEY isn't set, the metrics can't be sent to DataDog but the command is run normally
 
 OPTIONS:
   --help, -h                     show help

--- a/pkg/constant/help.go
+++ b/pkg/constant/help.go
@@ -10,7 +10,7 @@ USAGE:
 
 ENVIRONMENT VARIABLE
 
-  DATADOG_APK_KEY (required) - DataDog APK Key
+  DATADOG_API_KEY - DataDog API Key. If DATADOG_API_KEY isn't set, the metrics can't be sent to DataDog but the command is run normally
 
 OPTIONS:
   --help, -h                     show help


### PR DESCRIPTION
When we test CI/CD at localhost, we don't want to post the metrics to DataDog but run the command normally.